### PR TITLE
fix: update import path for InteractionDatabaseService

### DIFF
--- a/desktop/src/services/db/index.ts
+++ b/desktop/src/services/db/index.ts
@@ -1,7 +1,7 @@
 import { Tab } from '../../models/tabs';
 import { Workspace } from '../../models/workspaces';
 import { DatabaseService } from './db-service';
-import { InteractionDatabaseService } from './interaction-db-service';
+import { InteractionDatabaseService } from './db-service-interaction';
 
 export { DatabaseService, InteractionDatabaseService };
 


### PR DESCRIPTION
- updates the import statement for `InteractionDatabaseService` 
   - uses the correct file path 
   - `./db-service-interaction` instead of `./interaction-db-service` 
   - resolves not found error when building or running the project.