### PR TITLE
Fix Ollama support

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,15 +13,18 @@
     "dev:web": "vite"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^1.3.10",
     "@unternet/kernel": "*",
     "@unternet/sdk": "^0.1.1",
     "@web-applets/sdk": "^0.2.6",
+    "classnames": "^2.5.1",
     "dexie": "^4.0.11",
     "electron-is-dev": "^3.0.1",
     "immer": "^10.1.1",
     "lit": "^3.2.1",
     "lucide": "^0.484.0",
     "marked": "^15.0.7",
+    "ollama-ai-provider": "^1.2.0",
     "openai": "^4.91.1",
     "ulid": "^2.4.0"
   },

--- a/desktop/src/ai/kernel.ts
+++ b/desktop/src/ai/kernel.ts
@@ -65,7 +65,7 @@ export class Kernel {
     const recentInteractions = this.workspaceModel.allInteractions(workspaceId);
     const output = await this.interpreter.generateResponse(recentInteractions);
 
-    if (output.type === 'text') {
+    if (output?.type === 'text') {
       const outputIndex = this.workspaceModel.addOutput(interaction.id, {
         type: output.type,
         content: '',
@@ -79,6 +79,8 @@ export class Kernel {
           text
         );
       }
+    } else {
+      // NOTE: Should probably handle the `null` case
     }
   }
 }

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -15,12 +15,8 @@
     "run:example": "cd example && npx tsx src/index.ts"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.0.10",
-    "@web-applets/sdk": "^0.1.5",
-    "ai": "^4.0.20",
+    "ai": "^4.3.4",
     "dedent": "^1.5.3",
-    "ollama-ai-provider": "^1.2.0",
-    "openai": "^4.76.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/kernel/src/interpreter.ts
+++ b/kernel/src/interpreter.ts
@@ -83,7 +83,13 @@ export class Interpreter {
     });
 
     const { functions } = output.object as ActionChoiceObject;
-    if (!functions || !functions[0]?.id) return null;
+    if (!functions || !functions[0]?.id) {
+      // Ollama (qwen2.5-coder) returns an object with a `text` property
+      if ('text' in (output.object as any)) return { protocol: 'text' };
+
+      // Object generation is most likely not supported by the model used
+      return null;
+    }
 
     const fn = functions[0];
     const { protocol, resourceId, actionId } = decodeActionUri(fn.id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
         "kernel",
         "desktop"
       ],
-      "dependencies": {
-        "classnames": "^2.5.1"
-      },
       "devDependencies": {
         "concurrently": "^9.1.2",
         "husky": "^9.1.7",
@@ -29,15 +26,18 @@
       "version": "0.3.4",
       "license": "ISC",
       "dependencies": {
+        "@ai-sdk/openai": "^1.3.10",
         "@unternet/kernel": "*",
         "@unternet/sdk": "^0.1.1",
         "@web-applets/sdk": "^0.2.6",
+        "classnames": "^2.5.1",
         "dexie": "^4.0.11",
         "electron-is-dev": "^3.0.1",
         "immer": "^10.1.1",
         "lit": "^3.2.1",
         "lucide": "^0.484.0",
         "marked": "^15.0.7",
+        "ollama-ai-provider": "^1.2.0",
         "openai": "^4.91.1",
         "ulid": "^2.4.0"
       },
@@ -53,12 +53,8 @@
       "version": "0.3.4",
       "license": "ISC",
       "dependencies": {
-        "@ai-sdk/openai": "^1.0.10",
-        "@web-applets/sdk": "^0.1.5",
-        "ai": "^4.0.20",
+        "ai": "^4.3.4",
         "dedent": "^1.5.3",
-        "ollama-ai-provider": "^1.2.0",
-        "openai": "^4.76.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -66,20 +62,13 @@
         "typescript": "^5.8.2"
       }
     },
-    "kernel/node_modules/@web-applets/sdk": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@web-applets/sdk/-/sdk-0.1.5.tgz",
-      "integrity": "sha512-Tks+p2t2d0aihWsKy4gq2tfaV49RxUx/kKfsqd3UqGrwSN1QP1769yVPjpDYU1m5Sybz80JYamUSoBiQTzvJDg==",
-      "license": "MIT"
-    },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.6.tgz",
-      "integrity": "sha512-Lyp6W6dg+ERMJru3DI8/pWAjXLB0GbMMlXh4jxA3mVny8CJHlCAjlEJRuAdLg1/CFz4J1UDN2/4qBnIWtLFIqw==",
-      "license": "Apache-2.0",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.10.tgz",
+      "integrity": "sha512-XO0wF2lmAMWCYjkM5bLpWTKoXet61fBiIimTi+blqEGiLUjAvivt/1zZL1Lzhrv9+p19IC1rn9EWZI1dCelV8w==",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.0",
-        "@ai-sdk/provider-utils": "2.2.3"
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6"
       },
       "engines": {
         "node": ">=18"
@@ -89,10 +78,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.0.tgz",
-      "integrity": "sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew==",
-      "license": "Apache-2.0",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.2.tgz",
+      "integrity": "sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -101,12 +89,11 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.3.tgz",
-      "integrity": "sha512-o3fWTzkxzI5Af7U7y794MZkYNEsxbjLam2nxyoUZSScqkacb7vZ3EYHLh21+xCcSSzEC161C7pZAGHtC0hTUMw==",
-      "license": "Apache-2.0",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.6.tgz",
+      "integrity": "sha512-sUlZ7Gnq84DCGWMQRIK8XVbkzIBnvPR1diV4v6JwPgpn5armnLI/j+rqn62MpLrU5ZCQZlDKl/Lw6ed3ulYqaA==",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.0",
+        "@ai-sdk/provider": "1.1.2",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
       },
@@ -118,13 +105,12 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.5.tgz",
-      "integrity": "sha512-0jOop3S2WkDOdO4X5I+5fTGqZlNX8/h1T1eYokpkR9xh8Vmrxqw8SsovqGvrddTsZykH8uXRsvI+G4FTyy894A==",
-      "license": "Apache-2.0",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.8.tgz",
+      "integrity": "sha512-S2FzCSi4uTF0JuSN6zYMXyiAWVAzi/Hho8ISYgHpGZiICYLNCP2si4DuXQOsnWef3IXzQPLVoE11C63lILZIkw==",
       "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.3",
-        "@ai-sdk/ui-utils": "1.2.4",
+        "@ai-sdk/provider-utils": "2.2.6",
+        "@ai-sdk/ui-utils": "1.2.7",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -142,13 +128,12 @@
       }
     },
     "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.4.tgz",
-      "integrity": "sha512-wLTxEZrKZRyBmlVZv8nGXgLBg5tASlqXwbuhoDu0MhZa467ZFREEnosH/OC/novyEHTQXko2zC606xoVbMrUcA==",
-      "license": "Apache-2.0",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.7.tgz",
+      "integrity": "sha512-OVRxa4SDj0wVsMZ8tGr/whT89oqNtNoXBKmqWC2BRv5ZG6azL2LYZ5ZK35u3lb4l1IE7cWGsLlmq0py0ttsL7A==",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.0",
-        "@ai-sdk/provider-utils": "2.2.3",
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6",
         "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
@@ -1069,15 +1054,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.2.11.tgz",
-      "integrity": "sha512-XvYFz+I2MNpkNeso/cEvm2q22cuU7B3EdUxGyhpa94gHbb3HEk73d42+UPJqweSBmoXA52mZ9qvb6jt3P4TITQ==",
-      "license": "Apache-2.0",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.4.tgz",
+      "integrity": "sha512-uMjzrowIqfU8CCCxhx8QGl7ETydHBROeNL0VoEwetkmDCY6Q8ZTacj6jNNqGJOiCk595aUrGR9VHPY9Ylvy1fg==",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.0",
-        "@ai-sdk/provider-utils": "2.2.3",
-        "@ai-sdk/react": "1.2.5",
-        "@ai-sdk/ui-utils": "1.2.4",
+        "@ai-sdk/provider": "1.1.2",
+        "@ai-sdk/provider-utils": "2.2.6",
+        "@ai-sdk/react": "1.2.8",
+        "@ai-sdk/ui-utils": "1.2.7",
         "@opentelemetry/api": "1.9.0",
         "jsondiffpatch": "0.6.0"
       },
@@ -1498,8 +1482,7 @@
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -1857,7 +1840,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3207,7 +3189,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ollama-ai-provider/-/ollama-ai-provider-1.2.0.tgz",
       "integrity": "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "^1.0.0",
         "@ai-sdk/provider-utils": "^2.0.0",
@@ -3348,8 +3329,7 @@
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -3494,7 +3474,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3894,7 +3873,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
       "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
-      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.4.0"
@@ -3907,7 +3885,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
       "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4008,7 +3985,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -4302,7 +4278,6 @@
       "version": "3.24.5",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
-  },
-  "dependencies": {
-    "classnames": "^2.5.1"
   }
 }


### PR DESCRIPTION
I had trouble running Ollama, this PR fixes that by detecting the `text` property in the response object in the `createDirective` method. The OpenAI provider uses the `tool` method underneath in `generateObject`, but that method (which you can set manually) does not seem to work for Ollama. Hence the current solution.

Additionally, I saw that some dependencies were specified in the wrong places and I moved them to the correct location; and updated the `ai` package in the kernel.