### PR TITLE
doc: Some code documentation for the kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 **/.DS_Store
 .vscode/
 dist
+/kernel/docs/

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "chokidar 'src/**/*' -c 'npm run build'",
+    "docs": "typedoc",
     "example": "cd example && npx tsx src/index.ts",
     "test": "vitest --root tests --watch=false",
     "test:dev": "vitest --root tests --watch"
@@ -33,6 +34,7 @@
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "mime-types": "^3.0.1",
+    "typedoc": "^0.28.2",
     "typescript": "^5.8.2",
     "vitest": "^3.1.1"
   }

--- a/kernel/src/actions/actions.ts
+++ b/kernel/src/actions/actions.ts
@@ -1,11 +1,21 @@
 import { ActionRecord, Resource } from './resources';
 
+/**
+ * An instruction of how an action should be consumed.
+ */
 export interface ActionDirective {
   uri: string;
   actionId: string;
   args?: Record<string, any>;
 }
 
+/**
+ * Creates an action dictionary indexed by the action handle
+ * from the given resources.
+ *
+ * @param resources
+ * @returns Action dictionary/record/map.
+ */
 export function createActionRecord(resources: Resource[]): ActionRecord {
   const actions: ActionRecord = {};
 
@@ -25,14 +35,26 @@ interface UriComponents {
   actionId: string;
 }
 
-// Create a full tool ID that incorporates the resource
-// for use ONLY by the model
+/**
+ * Create a full tool ID that incorporates the resource
+ * for use ONLY by the model.
+ *
+ * @param uri The action-directive URI.
+ * @param actionId The id belonging to the action.
+ * @returns The action handle.
+ */
 export function encodeActionHandle(uri: string, actionId: string) {
   // https://my-applet.example.com->action_id
-  if (actionId) uri += `->${actionId}`;
+  if (actionId) return `${uri}->${actionId}`;
   return uri;
 }
 
+/**
+ * Decompose an action handle into its components.
+ *
+ * @param actionHandle The action handle.
+ * @returns The components extracted from the URI.
+ */
 export function decodeActionHandle(actionHandle: string): UriComponents {
   let [uri, actionId] = actionHandle.split('->');
 

--- a/kernel/src/actions/dispatcher.ts
+++ b/kernel/src/actions/dispatcher.ts
@@ -1,6 +1,10 @@
 import { ActionDirective } from './actions';
 import { createProtocolHandlers, Protocol, ProtocolHandler } from './protocols';
 
+/**
+ * Dispatchers pass on the action directives to their associated
+ * protocol handler based on the protocol used in the directive URI.
+ */
 export class Dispatcher {
   handlers: Record<string, ProtocolHandler> = {};
 

--- a/kernel/src/actions/protocols.ts
+++ b/kernel/src/actions/protocols.ts
@@ -1,5 +1,14 @@
 import { ActionDirective } from './actions';
 
+/**
+ * Protocols determine how an `ActionDirective` is executed.
+ *
+ * This goes hand in hand with `Resource`s.
+ * Each protocol has a unique `scheme`.
+ *
+ * {@link ActionDirective}
+ * {@link Resource}
+ */
 export interface Protocol {
   scheme: string;
   handler: ProtocolHandler;
@@ -9,6 +18,12 @@ export type ProtocolHandler = (
   directive: ActionDirective
 ) => any | Promise<any>;
 
+/**
+ * Creates a protocol-handlers dictionary indexed by the protocol scheme.
+ *
+ * @param protocols
+ * @returns Protocol dictionary/record/map.
+ */
 export function createProtocolHandlers(protocols: Protocol[]) {
   const handlers: Record<string, ProtocolHandler> = {};
   for (const protocol of protocols) {

--- a/kernel/src/actions/resources.ts
+++ b/kernel/src/actions/resources.ts
@@ -7,13 +7,34 @@ export interface ResourceIcon {
   type?: string;
 }
 
+/**
+ * A definition of an action.
+ *
+ * Lets the assistant know what inputs can be given
+ * in order to do something.
+ *
+ * {@link ActionDirective} Passing action parameters around.
+ * {@link Protocol} Processing actions.
+ */
 export interface ActionDefinition {
   description?: string;
   params_schema?: JSONSchemaDefinition;
 }
 
+/**
+ * Action dictionary, indexed by the action id.
+ */
 export type ActionRecord = { [id: string]: ActionDefinition };
 
+/**
+ * The properties needed to create a resource.
+ *
+ * A resource is anything that a model might use to get information
+ * or perform an action in response to an input.
+ *
+ * Or, in other words, it specifies how a `Protocol` could be consumed,
+ * along with some additional (optional) metadata.
+ */
 interface ResourceInit {
   uri?: string;
   protocol?: string;
@@ -21,9 +42,16 @@ interface ResourceInit {
   short_name?: string;
   icons?: ResourceIcon[];
   description?: string;
-  actions?: Record<string, ActionDefinition>;
+  actions?: ActionRecord;
 }
 
+/**
+ * A resource is anything that a model might use to get information
+ * or perform an action in response to an input.
+ *
+ * Or, in other words, it specifies how a `Protocol` could be consumed,
+ * along with some additional (optional) metadata.
+ */
 export class Resource {
   uri: string;
   protocol: string;
@@ -36,7 +64,7 @@ export class Resource {
   short_name?: string;
   icons?: ResourceIcon[];
   description?: string;
-  actions?: Record<string, ActionDefinition>;
+  actions?: ActionRecord;
 
   constructor(init: ResourceInit) {
     let urlObject: URL;

--- a/kernel/src/interpreter/interactions.ts
+++ b/kernel/src/interpreter/interactions.ts
@@ -29,6 +29,13 @@ export interface ActionOutput {
   content: any;
 }
 
+/**
+ * Utility function to create an `Interaction`
+ * based on a `InteractionInput` or a regular string.
+ *
+ * @param input The input for the interaction.
+ * @returns The interaction.
+ */
 export function createInteraction(
   input: InteractionInput | string
 ): Interaction {

--- a/kernel/src/interpreter/messages.ts
+++ b/kernel/src/interpreter/messages.ts
@@ -19,6 +19,12 @@ export type Message =
   | CoreUserMessage
   | CoreAssistantMessage;
 
+/**
+ * Utility function to create an `ai` user message.
+ *
+ * @param content Message content.
+ * @returns The user message.
+ */
 export function createUserMessage(content: string) {
   return {
     role: 'user',
@@ -26,6 +32,12 @@ export function createUserMessage(content: string) {
   } as Message;
 }
 
+/**
+ * Utility function to create an `ai` assistant message.
+ *
+ * @param content Message content.
+ * @returns The assistant message.
+ */
 export function createAssistantMessage(content: string) {
   return {
     role: 'assistant',
@@ -33,6 +45,14 @@ export function createAssistantMessage(content: string) {
   } as CoreAssistantMessage;
 }
 
+/**
+ * Translates a set of interactions and prompts into messages.
+ * These messages can be used with the `ai` SDK.
+ *
+ * @param interactions The interactions to translate.
+ * @param prompts Additional prompts to translate into user messages.
+ * @returns An array of messages.
+ */
 export function createMessages(
   interactions: Interaction[],
   ...prompts: string[] | undefined
@@ -83,6 +103,14 @@ export function createMessages(
   return messages;
 }
 
+/**
+ * Translate `FileInput` into an appropriate `ai` message.
+ * Text files are translated into a `TextPart`,
+ * images into a `ImagePart`, and other files into a `FilePart`.
+ *
+ * @param file The file input to translate.
+ * @returns The appropriate part.
+ */
 export function fileMessage(file: FileInput): TextPart | ImagePart | FilePart {
   if (
     file.mimeType?.startsWith('text/') ||

--- a/kernel/src/shared/types.ts
+++ b/kernel/src/shared/types.ts
@@ -1,10 +1,3 @@
-import type {
-  CoreSystemMessage,
-  CoreUserMessage,
-  CoreAssistantMessage,
-  CoreToolMessage,
-} from 'ai';
-
 export { Schema } from 'ai';
 
 export interface JSONSchemaDefinition {

--- a/kernel/src/shared/utils.ts
+++ b/kernel/src/shared/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * Make a copy of an object.
+ *
+ * @param obj Any Javascript object (not just a record)
+ * @returns The copy.
+ */
 export function clone(obj: Object) {
   return JSON.parse(JSON.stringify(obj));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "mime-types": "^3.0.1",
+        "typedoc": "^0.28.2",
         "typescript": "^5.8.2",
         "vitest": "^3.1.1"
       }
@@ -628,6 +629,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.3.tgz",
+      "integrity": "sha512-yemSYr0Oiqk5NAQRfbD5DKUTlThiZw1MxTMx/YpQTg6m4QRJDtV2JTYSuNevgx1ayy/O7x+uwDjh3IgECGFY/Q==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.2.2",
+        "@shikijs/langs": "^3.2.2",
+        "@shikijs/themes": "^3.2.2",
+        "@shikijs/types": "^3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -938,6 +952,50 @@
         "win32"
       ]
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
+      "integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
+      "integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "3.2.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
+      "integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/types": "3.2.2"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
+      "integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
+      "dev": true,
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -990,6 +1048,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -1041,6 +1108,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -1288,6 +1361,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1302,6 +1381,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1324,6 +1409,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2142,6 +2236,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -2968,6 +3074,15 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.0.tgz",
@@ -3181,6 +3296,12 @@
       "integrity": "sha512-GpDcrcHyPVqxp8xWL4UHDLtUUHvrqxLtR4YVq8lK/vVxaGAtp+MmL0WXPFyRlX4Cn+uOHnHYPOt3pjROdE+XPw==",
       "license": "ISC"
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3188,6 +3309,23 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/marked": {
@@ -3224,6 +3362,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -3301,6 +3445,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3716,6 +3875,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/quick-lru": {
@@ -4263,6 +4431,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.2.tgz",
+      "integrity": "sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==",
+      "dev": true,
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.2",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
@@ -4276,6 +4467,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true
     },
     "node_modules/ulid": {
       "version": "2.4.0",


### PR DESCRIPTION
Couple code comments (copies a tiny bit from the README in kernel).

## Typedoc

This also adds the `npm run docs` command in the kernel which generates some HTML Typescript documentation in `docs`. You can just open this as a file, no static web server needed. By default it looks at what is exported through `src/index.ts`.  When you generate docs, you'll see warnings for types that are not exported but does have code exported that uses those types. This is useful in order to provide code to people that is well-typed and can be used to its full extent.