### PR TITLE
fix: clear kernel dist before build

### DIFF
--- a/kernel/package.json
+++ b/kernel/package.json
@@ -10,7 +10,7 @@
     "example": "example"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf dist && tsc",
     "dev": "chokidar 'src/**/*' -c 'npm run build'",
     "docs": "typedoc",
     "example": "cd example && npx tsx src/index.ts",
@@ -35,6 +35,7 @@
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "mime-types": "^3.0.1",
+    "rimraf": "^6.0.1",
     "typedoc": "^0.28.2",
     "typescript": "^5.8.2",
     "vitest": "^3.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "mime-types": "^3.0.1",
+        "rimraf": "^6.0.1",
         "typedoc": "^0.28.2",
         "typescript": "^5.8.2",
         "vitest": "^3.1.1"
@@ -6259,8 +6260,9 @@
     },
     "node_modules/rimraf": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^11.0.0",
         "package-json-from-dist": "^1.0.0"


### PR DESCRIPTION
Fixes #187

Kernel code was built, but because some old files were still there it didn't pick up the new code.