### PR TITLE
feat: improve strategy choosing

### DIFF
--- a/kernel/src/interpreter/prompts.ts
+++ b/kernel/src/interpreter/prompts.ts
@@ -6,15 +6,25 @@ function chooseStrategy(strategies: Record<string, Strategy>) {
   const possibleOutputs = Object.keys(strategies)
     .map((x) => `"${x}"`)
     .join('|');
+  const descriptions = JSON.stringify(strategies);
   return dedent`
     Choose from one of the following available strategies to use in order to best respond to the user's query. (This is not your actual response, but will determine the type of response you give).
     Available strategies are listed below in a discriminated union format with the name Strategy.
+    \`\`\`
     type Strategy = ${possibleOutputs};
+    \`\`\`
+    Be sure to look at the name and description of each strategy.
+    Here is a JSON object that maps each strategy to its associated description:
+    \`\`\`
+    ${descriptions}
+    \`\`\`
     Your response should take the form of a JSON object that adheres to this interface:
+    \`\`\`
     interface Response {
       strategy: Strategy;
-    };    
-    Where the response is an object with key "strategy" and values one of the allowed strings in the discriminated union ${possibleOutputs}. 
+    };
+    \`\`\`
+    Where the response is an object with key "strategy" and the value is one of the allowed strings in the discriminated union given previously.
     Respond with the strategy you think is best for the user query in the JSON format mentioned above.
   `;
 }


### PR DESCRIPTION
Was experimenting with some improvements to how the assistant can choose a strategy. This seems to work a bit better. Mainly it adds the descriptions of the actions to the prompt as well so the assistant has more info to base its decision on.