### PR TITLE
Style/workspace selector

### DIFF
--- a/desktop/src/electron/main.ts
+++ b/desktop/src/electron/main.ts
@@ -9,6 +9,7 @@ import {
 import path from 'path';
 import log from 'electron-log';
 import { autoUpdater } from 'electron-updater';
+import { registerNativeMenuHandler } from './menu';
 
 const isDev = !app.isPackaged;
 const AUTOUPDATE_INTERVAL = 3_600_000; // 60 * 60 * 1000
@@ -175,6 +176,8 @@ ipcMain.handle('isFullScreen', (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   return win ? win.isFullScreen() : false;
 });
+
+registerNativeMenuHandler(ipcMain);
 
 // ipcMain.on('request-applets', async (event) => {
 //   const appletsPath = app.getPath('userData') + '/applets';

--- a/desktop/src/electron/menu.ts
+++ b/desktop/src/electron/menu.ts
@@ -1,0 +1,56 @@
+import { Menu, BrowserWindow, ipcMain, IpcMainInvokeEvent } from 'electron';
+
+function buildMenu(
+  items: any[],
+  selectedId: string | null,
+  event: IpcMainInvokeEvent,
+  setSelected: (id: string) => void
+): any[] {
+  return items.map((opt) => {
+    if (opt.type === 'separator') return { type: 'separator' };
+    const isSubmenu = Array.isArray(opt.submenu);
+    const menuItem = {
+      ...opt,
+      click:
+        !isSubmenu && opt.id
+          ? () => {
+              setSelected(opt.id);
+              return opt.id;
+            }
+          : undefined,
+      submenu: isSubmenu
+        ? buildMenu(opt.submenu, selectedId, event, setSelected)
+        : undefined,
+    };
+    return menuItem;
+  });
+}
+
+export function registerNativeMenuHandler(ipcMainInst: typeof ipcMain) {
+  ipcMainInst.handle(
+    'showNativeMenu',
+    async (event, options, selectedValue, position) => {
+      let selected: string | null = null;
+      function setSelected(val: string) {
+        selected = val;
+      }
+      return await new Promise((resolve) => {
+        const menuObject = buildMenu(
+          options,
+          selectedValue,
+          event,
+          setSelected
+        );
+        const menu = Menu.buildFromTemplate(menuObject);
+        menu.popup({
+          window: BrowserWindow.fromWebContents(event.sender) || undefined,
+          x: position?.x,
+          y: position?.y,
+          callback: () => {
+            resolve(selected);
+          },
+        });
+      });
+    }
+  );
+}

--- a/desktop/src/electron/preload.ts
+++ b/desktop/src/electron/preload.ts
@@ -6,6 +6,18 @@ contextBridge.exposeInMainWorld('system', {
 
 // Expose simplified electron API for window state
 contextBridge.exposeInMainWorld('electronAPI', {
+  ipcRenderer: {
+    on: ipcRenderer.on.bind(ipcRenderer),
+    removeListener: ipcRenderer.removeListener.bind(ipcRenderer),
+  },
+  showNativeMenu: (options, selectedValue, position) => {
+    return ipcRenderer.invoke(
+      'showNativeMenu',
+      options,
+      selectedValue,
+      position
+    );
+  },
   platform: process.platform,
   onWindowStateChange: (callback) => {
     // Handle fullscreen event

--- a/desktop/src/ui/common/electron-api.d.ts
+++ b/desktop/src/ui/common/electron-api.d.ts
@@ -1,10 +1,18 @@
 declare global {
   interface Window {
     electronAPI?: {
+      showNativeMenu?: (
+        options: MenuItemConstructorOptions[],
+        selectedValue: string | null,
+        position?: { x?: number; y?: number }
+      ) => Promise<string | null>;
       onWindowStateChange: (callback: (isFullscreen: boolean) => void) => void;
       removeWindowStateListeners: () => void;
       platform: string;
       isFullScreen: () => Promise<boolean>;
+      ipcRenderer: IpcRenderer;
     };
   }
 }
+
+export {};

--- a/desktop/src/ui/common/electron-api.d.ts
+++ b/desktop/src/ui/common/electron-api.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface Window {
+    electronAPI?: {
+      onWindowStateChange: (callback: (isFullscreen: boolean) => void) => void;
+      removeWindowStateListeners: () => void;
+      platform: string;
+      isFullScreen: () => Promise<boolean>;
+    };
+  }
+}

--- a/desktop/src/ui/common/elements/icon-registry.ts
+++ b/desktop/src/ui/common/elements/icon-registry.ts
@@ -1,0 +1,137 @@
+import {
+  IconNode,
+  HelpCircle,
+  X,
+  Home,
+  Plus,
+  Bug,
+  Shapes,
+  Settings,
+  Pencil,
+  Settings2,
+  Check,
+  ChevronsUpDown,
+  CornerDownLeft,
+  GripHorizontal,
+  Trash,
+  History,
+  RefreshCw,
+  AlertTriangle,
+  Loader,
+  Info,
+  ExternalLink,
+  Download,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ArrowDown,
+  Search,
+  Upload,
+  Paperclip,
+  CheckCheck,
+} from 'lucide';
+import { broom } from '@lucide/lab';
+
+export const icons = {
+  HelpCircle,
+  X,
+  Home,
+  Plus,
+  Bug,
+  Shapes,
+  Settings,
+  Pencil,
+  Settings2,
+  Check,
+  ChevronsUpDown,
+  CornerDownLeft,
+  GripHorizontal,
+  Trash,
+  History,
+  RefreshCw,
+  AlertTriangle,
+  Loader,
+  Info,
+  ExternalLink,
+  Download,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ArrowDown,
+  Search,
+  Upload,
+  Paperclip,
+  CheckCheck,
+  Broom: broom,
+} as const;
+
+export type CanonicalIconName = keyof typeof icons;
+export type IconName =
+  | CanonicalIconName
+  | keyof typeof ALIASES
+  | Lowercase<CanonicalIconName>
+  | string;
+
+export const ALIASES: Record<string, CanonicalIconName> = {
+  close: 'X',
+  toolbox: 'Shapes',
+  sliders: 'Settings2',
+  dropdown: 'ChevronsUpDown',
+  enter: 'CornerDownLeft',
+  handle: 'GripHorizontal',
+  delete: 'Trash',
+  refresh: 'RefreshCw',
+  error: 'AlertTriangle',
+  loading: 'Loader',
+  external: 'ExternalLink',
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  attachment: 'Paperclip',
+  archive: 'Broom',
+};
+
+export type IconFactory = (attrs: Record<string, any>) => IconNode;
+
+export function getIcon(name: IconName): IconFactory {
+  const wrapIconNode =
+    (node: IconNode): IconFactory =>
+    (_attrs: Record<string, any>) =>
+      node;
+  if (!name) return wrapIconNode(icons.HelpCircle);
+
+  // Resolve alias
+  let canonical = name as string;
+  if (ALIASES[canonical as keyof typeof ALIASES]) {
+    canonical = ALIASES[canonical as keyof typeof ALIASES];
+  }
+
+  // Prepare candidate keys to try in order
+  const pascal = canonical.replace(
+    /(^|[-_])(\w)/g,
+    (_: string, __: string, p2: string) => p2.toUpperCase()
+  );
+  const capFirst = canonical.charAt(0).toUpperCase() + canonical.slice(1);
+  const lower = canonical.toLowerCase();
+  const keysToTry = [canonical, pascal, capFirst];
+
+  // Try direct keys
+  for (const key of keysToTry) {
+    const candidate = (icons as any)[key];
+    if (typeof candidate === 'function') return candidate;
+    if (candidate) return wrapIconNode(candidate);
+  }
+
+  // Try any key matching lowercased name
+  for (const key of Object.keys(icons)) {
+    if (key.toLowerCase() === lower) {
+      const icon = (icons as any)[key];
+      if (typeof icon === 'function') return icon;
+      if (icon) return wrapIconNode(icon);
+    }
+  }
+
+  // Fallback
+  return wrapIconNode(icons.HelpCircle);
+}

--- a/desktop/src/ui/common/elements/select-native-menu.ts
+++ b/desktop/src/ui/common/elements/select-native-menu.ts
@@ -1,0 +1,185 @@
+import type { MenuItemConstructorOptions } from 'electron';
+export interface NativeMenuOption extends MenuItemConstructorOptions {
+  value: string;
+}
+
+/**
+ * Encapsulates the logic for building native menu options, mapping selection IDs to values,
+ * and managing native menu event handlers for Electron environments.
+ */
+export class SelectNativeMenu {
+  #idValueMap = new Map<string, string>();
+  #idx = 0;
+  #handlerMap: WeakMap<HTMLElement, EventListener> = new WeakMap();
+
+  /**
+   * Normalizes a string or object to a NativeMenuOption array.
+   * Accepts JSON strings, arrays, or objects with an 'options' field.
+   */
+  static parseOptions(
+    optionsAttr: string | object | null | undefined
+  ): NativeMenuOption[] {
+    if (!optionsAttr) return [];
+    if (typeof optionsAttr === 'string') {
+      try {
+        const parsed = JSON.parse(optionsAttr);
+        if (Array.isArray(parsed)) return parsed;
+        if (parsed?.options && Array.isArray(parsed.options))
+          return parsed.options;
+        return [];
+      } catch {
+        return [];
+      }
+    }
+    if (Array.isArray(optionsAttr)) return optionsAttr;
+    if (
+      (optionsAttr as any)?.options &&
+      Array.isArray((optionsAttr as any).options)
+    ) {
+      return (optionsAttr as any).options;
+    }
+    return [];
+  }
+
+  /**
+   * Recursively flattens options and finds the label for a given value.
+   */
+  static findLabelForValue(
+    options: NativeMenuOption[],
+    value: string | null | undefined
+  ): string | undefined {
+    if (!value) return undefined;
+    const flat = this.#flatten(options);
+    return flat.find((opt) => opt.value === value)?.label;
+  }
+
+  // Private static flatten helper for NativeMenuOption trees
+  static #flatten(opts: NativeMenuOption[]): NativeMenuOption[] {
+    return opts.flatMap((opt) =>
+      Array.isArray(opt.submenu)
+        ? [opt, ...this.#flatten(opt.submenu as NativeMenuOption[])]
+        : [opt]
+    );
+  }
+
+  /**
+   * Builds Electron menu options from NativeMenuOption[] and maps unique IDs to values.
+   * @param options NativeMenuOption[]
+   * @returns MenuItemConstructorOptions[]
+   */
+  buildMenuOptions(options: NativeMenuOption[]): MenuItemConstructorOptions[] {
+    this.#idValueMap.clear();
+    this.#idx = 0;
+    return this.#recurse(options);
+  }
+
+  /**
+   * Internal recursive builder for menu options.
+   */
+  #recurse(opts: NativeMenuOption[]): MenuItemConstructorOptions[] {
+    return opts.map((opt) => {
+      const { value, submenu, ...rest } = opt as NativeMenuOption & {
+        submenu?: NativeMenuOption[];
+      };
+      if (rest.label === undefined && rest.type !== 'separator') {
+        throw new Error(
+          `Menu items must have a label. Problematic option: ${JSON.stringify(opt)}`
+        );
+      }
+      if (rest.type === 'separator') return { type: 'separator' };
+      const id = `menu-item-${this.#idx++}`;
+      this.#idValueMap.set(id, value);
+      return {
+        ...rest,
+        id,
+        ...(Array.isArray(submenu) ? { submenu: this.#recurse(submenu) } : {}),
+      };
+    });
+  }
+
+  /**
+   * Returns the value associated with a menu item ID.
+   * @param id string
+   */
+  getValueForId(id: string): string | undefined {
+    return this.#idValueMap.get(id);
+  }
+
+  /**
+   * Registers the native menu click event handler on the given element.
+   * Handles value comparison, updating, and event dispatch internally.
+   * @param el HTMLElement
+   * @param getOptions () => NativeMenuOption[]
+   * @param getValue () => string | null
+   * @param setValue (value: string) => void
+   */
+  registerEvents(
+    el: HTMLElement,
+    getOptions: () => NativeMenuOption[],
+    getValue: () => string | null,
+    setValue: (value: string) => void
+  ) {
+    this.unregisterEvents(el); // Always clean up before registering
+    const handler = this.#handleNativeMenuClick.bind(
+      this,
+      el,
+      getOptions,
+      getValue,
+      setValue
+    );
+    el.addEventListener('click', handler);
+    this.#handlerMap.set(el, handler);
+  }
+
+  /**
+   * Unregisters the native menu click event handler from the given element.
+   * @param el HTMLElement
+   */
+  unregisterEvents(el: HTMLElement) {
+    const handler = this.#handlerMap.get(el);
+    if (handler) {
+      el.removeEventListener('click', handler);
+      this.#handlerMap.delete(el);
+    }
+  }
+
+  /**
+   * Handles click events for native menu (Electron only).
+   * @param el HTMLElement
+   * @param getOptions () => NativeMenuOption[]
+   * @param onValue (value: string) => void
+   * @param e MouseEvent
+   */
+  async #handleNativeMenuClick(
+    el: HTMLElement,
+    getOptions: () => NativeMenuOption[],
+    getValue: () => string | null,
+    setValue: (value: string) => void,
+    e: MouseEvent
+  ) {
+    e.preventDefault();
+    e.stopPropagation();
+    const showNativeMenu = window.electronAPI?.showNativeMenu;
+    if (!showNativeMenu) return;
+    const menuOptions = this.buildMenuOptions(getOptions());
+    const button = (el.shadowRoot || el).querySelector(
+      'button.select--native'
+    ) as HTMLElement | null;
+    const rect = button?.getBoundingClientRect();
+    const x = rect ? Math.round(rect.left) : undefined;
+    const y = rect ? Math.round(rect.top) : undefined;
+    const selectedId = await showNativeMenu(menuOptions, null, { x, y });
+    const value =
+      selectedId != null ? this.getValueForId(selectedId) : undefined;
+    if (value && value !== getValue()) {
+      setValue(value);
+      el.dispatchEvent(
+        new CustomEvent('change', {
+          detail: { value },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
+  }
+}

--- a/desktop/src/ui/common/elements/select.ts
+++ b/desktop/src/ui/common/elements/select.ts
@@ -13,6 +13,10 @@ export class SelectElement extends HTMLElement {
   #selectNativeMenu?: SelectNativeMenu;
   #disposables = new DisposableGroup();
 
+  static get observedAttributes() {
+    return ['value'];
+  }
+
   constructor() {
     super();
     this.attachShadow({ mode: 'open', delegatesFocus: true });
@@ -45,6 +49,12 @@ export class SelectElement extends HTMLElement {
     }
   }
 
+  attributeChangedCallback(name: string, oldValue: any, newValue: any) {
+    if (name === 'value' && oldValue !== newValue) {
+      render(this.#template, this.shadowRoot!);
+    }
+  }
+
   #registerNativeMenuEvents() {
     if (!this.#selectNativeMenu) {
       this.#selectNativeMenu = new SelectNativeMenu();
@@ -72,6 +82,15 @@ export class SelectElement extends HTMLElement {
   }
   get options(): any[] {
     return (this as any)._options;
+  }
+
+  set value(val: string) {
+    if (val !== this.getAttribute('value')) {
+      this.setAttribute('value', val);
+    }
+  }
+  get value(): string {
+    return this.getAttribute('value') ?? '';
   }
 
   get #wrapperClasses() {

--- a/desktop/src/ui/common/elements/select.ts
+++ b/desktop/src/ui/common/elements/select.ts
@@ -1,5 +1,4 @@
-import { LitElement, html, css } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
+import { html, css, render } from 'lit';
 import './icon';
 
 export interface SelectOption {
@@ -12,99 +11,64 @@ export type SelectSize = 'small' | 'medium' | 'large';
 export type SelectVariant = 'default' | 'ghost' | 'flat';
 export type IconPosition = 'start' | 'end';
 
-export class SelectElement extends LitElement {
+export class SelectElement extends HTMLElement {
   private _mutationObserver?: MutationObserver;
+  private _selectEl?: HTMLSelectElement;
 
-  value: string = '';
-  placeholder: string = '';
-  disabled: boolean = false;
-  required: boolean = false;
-  name: string = '';
-  size: SelectSize = 'medium';
-  variant: SelectVariant = 'default';
-  loading: boolean = false;
-  icon?: string;
-  iconPosition: IconPosition = 'end';
-
-  static get properties() {
-    return {
-      value: { type: String },
-      placeholder: { type: String },
-      disabled: { type: Boolean },
-      required: { type: Boolean },
-      name: { type: String },
-      size: { type: String },
-      variant: { type: String },
-      loading: { type: Boolean },
-      icon: { type: String },
-      iconPosition: { type: String, attribute: 'icon-position' },
-    };
+  static get observedAttributes() {
+    return [
+      'value',
+      'placeholder',
+      'disabled',
+      'required',
+      'name',
+      'size',
+      'variant',
+      'loading',
+      'icon',
+      'icon-position',
+    ];
   }
 
   constructor() {
     super();
-    this.size = 'medium';
-    this.variant = 'default';
-    this.loading = false;
-    this.icon = undefined;
-    this.iconPosition = 'end';
+    this.attachShadow({ mode: 'open' });
   }
 
-  // Watch change in children (e.g. options)
   connectedCallback() {
-    super.connectedCallback();
-    this._mutationObserver = new MutationObserver(() => {
-      this.requestUpdate();
-    });
+    this._mutationObserver = new MutationObserver(() => this.render());
     this._mutationObserver.observe(this, {
       childList: true,
       subtree: true,
       characterData: true,
     });
+    this.render();
   }
 
   disconnectedCallback() {
-    super.disconnectedCallback();
     this._mutationObserver?.disconnect();
+    if (this._selectEl) {
+      this._selectEl.removeEventListener('change', this.handleChange);
+    }
   }
 
-  updated() {
-    const selectElement = this.shadowRoot.querySelector('select');
-    if (!selectElement) return;
-
-    const options = Array.from(selectElement.querySelectorAll('option'));
-    const idx = options.findIndex((opt) => opt.value === this.value);
-
-    selectElement.selectedIndex = idx;
+  attributeChangedCallback() {
+    this.render();
   }
 
-  private handleChange(e: Event) {
-    const select = e.target as HTMLSelectElement;
-    this.value = select.value;
-
-    this.dispatchEvent(
-      new CustomEvent('change', {
-        detail: { value: this.value },
-        bubbles: true,
-        composed: true,
-      })
-    );
-  }
-
+  /**
+   * Focuses the select input.
+   */
   focus() {
-    const select = this.shadowRoot?.querySelector('select');
-    if (select) {
-      select.focus();
-    }
+    this._selectEl?.focus();
   }
-
   blur() {
-    const select = this.shadowRoot?.querySelector('select');
-    if (select) {
-      select.blur();
-    }
+    this._selectEl?.blur();
   }
 
+  /**
+   * Returns the options derived from child elements.
+   */
   private get options(): SelectOption[] {
     return Array.from(this.children).map((el) => ({
       value: el.getAttribute('value') || '',
@@ -113,77 +77,136 @@ export class SelectElement extends LitElement {
     }));
   }
 
-  render() {
-    const selectClasses = {
-      select: true,
-      [`select--${this.size}`]: this.size !== 'medium',
-      [`select--${this.variant}`]: this.variant !== 'default',
-      loading: this.loading,
-    };
+  private get wrapperClasses() {
+    const size = this.getAttribute('size');
+    const icon = this.getAttribute('icon');
+    const iconPosition = this.getAttribute('icon-position');
+    return [
+      'select-wrapper',
+      size && size !== 'medium' ? `select-wrapper--${size}` : '',
+      icon ? `has-icon icon-${iconPosition === 'start' ? 'start' : 'end'}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
 
-    const optionElements = [];
+  private get selectClasses() {
+    const size = this.getAttribute('size');
+    const variant = this.getAttribute('variant');
+    const loading = this.hasAttribute('loading');
+    return [
+      'select',
+      size && size !== 'medium' ? `select--${size}` : '',
+      variant && variant !== 'default' ? `select--${variant}` : '',
+      loading ? 'loading' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
 
-    if (this.placeholder) {
-      optionElements.push(html`
-        <option value="" disabled ?selected=${!this.value}>
-          ${this.placeholder}
-        </option>
-      `);
+  private renderOptions() {
+    const nodes = [];
+    const placeholder = this.getAttribute('placeholder');
+    const value = this.getAttribute('value');
+    if (placeholder) {
+      nodes.push(
+        html`<option value="" disabled ?selected=${!value}>
+          ${placeholder}
+        </option>`
+      );
     }
-
     this.options.forEach((opt) => {
-      optionElements.push(html`
-        <option
+      nodes.push(
+        html`<option
           value=${opt.value}
           ?disabled=${opt.disabled}
-          ?selected=${this.value === opt.value}
+          ?selected=${value === opt.value}
         >
           ${opt.label}
-        </option>
-      `);
+        </option>`
+      );
     });
+    return nodes;
+  }
 
-    return html`
-      <div
-        class="select-wrapper ${this.size !== 'medium'
-          ? `select-wrapper--${this.size}`
-          : ''} ${this.icon ? `has-icon icon-${this.iconPosition}` : ''}"
-      >
-        ${this.icon && this.iconPosition === 'start'
-          ? html`<un-icon
-              class="value-icon value-icon-start"
-              name=${this.icon}
-              size=${this.size}
-            ></un-icon>`
-          : ''}
-        <select
-          class=${classMap(selectClasses)}
-          .value=${this.value}
-          ?disabled=${this.disabled || this.loading}
-          ?required=${this.required}
-          name=${this.name}
-          @change=${this.handleChange}
-          aria-busy=${this.loading ? 'true' : 'false'}
-        >
-          ${optionElements}
-        </select>
-        ${this.icon && this.iconPosition === 'end'
-          ? html`<un-icon
-              class="value-icon value-icon-end"
-              name=${this.icon}
-              size=${this.size}
-            ></un-icon>`
-          : ''}
-        ${this.loading
-          ? html`<un-icon
-              class="dropdown-icon"
-              name="loading"
-              spin
-              size=${this.size}
-            ></un-icon>`
-          : html`<un-icon class="dropdown-icon" name="dropdown"></un-icon>`}
-      </div>
-    `;
+  private renderIcon(position: IconPosition) {
+    const icon = this.getAttribute('icon');
+    const iconPosition = this.getAttribute('icon-position');
+    const size = this.getAttribute('size') || 'medium';
+    if (!icon || iconPosition !== position) return null;
+    return html`<un-icon
+      class="value-icon value-icon-${position}"
+      name=${icon}
+      size=${size}
+    ></un-icon>`;
+  }
+
+  private renderDropdownIcon() {
+    const loading = this.hasAttribute('loading');
+    const size = this.getAttribute('size') || 'medium';
+    return loading
+      ? html`<un-icon
+          class="dropdown-icon"
+          name="loading"
+          spin
+          size=${size}
+        ></un-icon>`
+      : html`<un-icon class="dropdown-icon" name="dropdown"></un-icon>`;
+  }
+
+  /**
+   * Handles select value change.
+   */
+  private handleChange = (e: Event) => {
+    const select = e.target as HTMLSelectElement;
+    this.setAttribute('value', select.value);
+    this.dispatchEvent(
+      new CustomEvent('change', {
+        detail: { value: select.value },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
+
+  /**
+   * Renders the component template.
+   */
+  render() {
+    const value = this.getAttribute('value');
+    const disabled =
+      this.hasAttribute('disabled') || this.hasAttribute('loading');
+    const required = this.hasAttribute('required');
+    const name = this.getAttribute('name') ?? '';
+    const loading = this.hasAttribute('loading');
+    render(
+      html`
+        <style>
+          ${SelectElement.styles}
+        </style>
+        <div class="${this.wrapperClasses}">
+          ${this.renderIcon('start')}
+          <select
+            class=${this.selectClasses}
+            .value=${value}
+            ?disabled=${disabled}
+            ?required=${required}
+            name=${name}
+            aria-busy=${loading ? 'true' : 'false'}
+          >
+            ${this.renderOptions()}
+          </select>
+          ${this.renderIcon('end')} ${this.renderDropdownIcon()}
+        </div>
+      `,
+      this.shadowRoot!
+    );
+    // Attach event listener after render
+    this._selectEl = this.shadowRoot!.querySelector('select')!;
+    if (this._selectEl) {
+      this._selectEl.removeEventListener('change', this.handleChange);
+      this._selectEl.addEventListener('change', this.handleChange);
+    }
   }
 
   static get styles() {
@@ -191,15 +214,13 @@ export class SelectElement extends LitElement {
       :host {
         display: block;
         position: relative;
+        --select-height: 24px;
       }
-
       .select-wrapper {
         position: relative;
         width: 100%;
       }
-
       .select {
-        --select-height: 24px;
         width: 100%;
         height: var(--select-height);
         padding: 0 var(--space-8) 0 var(--space-4);
@@ -219,61 +240,50 @@ export class SelectElement extends LitElement {
         );
         box-shadow: var(--button-shadows);
       }
-
       .select:focus {
         outline: var(--outline);
         outline-offset: var(--outline-offset-inputs);
       }
-
       .select:disabled,
       .select.loading {
         opacity: 0.5;
         cursor: not-allowed;
       }
-
       .loading {
         pointer-events: none;
       }
-
       .select option:disabled {
         color: var(--input-placeholder-color);
       }
-
       .select--small {
         --select-height: 18px;
         font-size: var(--text-sm);
       }
-
       .select--large {
         --select-height: 28px;
       }
-
       .select--ghost {
         border-color: transparent;
         background-color: transparent;
         box-shadow: none;
-        font-weight: 500;
-        font-size: var(--text-sm);
+        /* font-weight: 500; */
+        /* font-size: var(--text-sm); */
         padding-right: var(--space-6);
-        margin-bottom: 2px;
+        /* margin-bottom: 2px; */
       }
-
       .select-wrapper:has(.select--ghost):hover un-icon.dropdown-icon {
         opacity: 1;
       }
-
       .select--flat {
         border-color: transparent;
         box-shadow: none;
         mix-blend-mode: multiply;
         background-color: var(--input-bg-color-flat);
       }
-
       .select--flat + un-icon.dropdown-icon,
       .select--flat ~ un-icon.dropdown-icon {
         border-left-color: transparent;
       }
-
       un-icon.dropdown-icon {
         position: absolute;
         right: 1px;
@@ -289,7 +299,6 @@ export class SelectElement extends LitElement {
         align-items: center;
         justify-content: center;
       }
-
       .select--ghost + un-icon.dropdown-icon,
       .select--ghost ~ un-icon.dropdown-icon {
         border: 1px solid var(--input-border-color);
@@ -304,7 +313,6 @@ export class SelectElement extends LitElement {
         width: 16px;
         right: var(--space-2);
       }
-
       un-icon.value-icon {
         position: absolute;
         top: 50%;
@@ -313,23 +321,18 @@ export class SelectElement extends LitElement {
         color: var(--input-text-color);
         z-index: 1;
       }
-
       un-icon.value-icon-start {
         left: var(--space-4);
       }
-
       un-icon.value-icon-end {
         right: calc(20px + var(--space-4));
       }
-
       .has-icon.icon-start select {
         padding-left: calc(var(--space-4) + 16px);
       }
-
       .has-icon.icon-end select {
         padding-right: calc(var(--space-8) + 16px);
       }
-
       select:disabled + un-icon {
         opacity: 0.5;
       }

--- a/desktop/src/ui/common/elements/select.ts
+++ b/desktop/src/ui/common/elements/select.ts
@@ -1,83 +1,80 @@
 import { html, css, render } from 'lit';
 import './icon';
-
-export interface SelectOption {
-  value: string;
-  label: string;
-  disabled?: boolean;
-}
+import { SelectNativeMenu } from './select-native-menu';
+import { Disposable, DisposableGroup } from '../../../common/disposable';
+import { attachStyles } from '../../../common/utils/dom';
 
 export type SelectSize = 'small' | 'medium' | 'large';
 export type SelectVariant = 'default' | 'ghost' | 'flat';
 export type IconPosition = 'start' | 'end';
 
 export class SelectElement extends HTMLElement {
-  private _mutationObserver?: MutationObserver;
-  private _selectEl?: HTMLSelectElement;
-
-  static get observedAttributes() {
-    return [
-      'value',
-      'placeholder',
-      'disabled',
-      'required',
-      'name',
-      'size',
-      'variant',
-      'loading',
-      'icon',
-      'icon-position',
-    ];
-  }
+  #mutationObserver?: MutationObserver;
+  #selectNativeMenu?: SelectNativeMenu;
+  #disposables = new DisposableGroup();
 
   constructor() {
     super();
-    this.attachShadow({ mode: 'open' });
+    this.attachShadow({ mode: 'open', delegatesFocus: true });
   }
 
   connectedCallback() {
-    this._mutationObserver = new MutationObserver(() => this.render());
-    this._mutationObserver.observe(this, {
+    this.#mutationObserver = new MutationObserver(() =>
+      render(this.#template, this.shadowRoot!)
+    );
+    this.#mutationObserver.observe(this, {
       childList: true,
       subtree: true,
       characterData: true,
+      attributes: true,
     });
-    this.render();
-  }
-
-  disconnectedCallback() {
-    this._mutationObserver?.disconnect();
-    if (this._selectEl) {
-      this._selectEl.removeEventListener('change', this.handleChange);
+    this.#disposables.add(
+      new Disposable(() => this.#mutationObserver?.disconnect())
+    );
+    attachStyles(this.shadowRoot!, SelectElement.styles.toString());
+    render(this.#template, this.shadowRoot!);
+    if (this.#useNativeMenu) {
+      this.#registerNativeMenuEvents();
     }
   }
 
-  attributeChangedCallback() {
-    this.render();
+  disconnectedCallback() {
+    this.#disposables.dispose();
+    if (this.#selectNativeMenu && this.#useNativeMenu) {
+      this.#selectNativeMenu.unregisterEvents(this);
+    }
   }
 
-  /**
-   * Focuses the select input.
-   */
-  focus() {
-    this._selectEl?.focus();
-  }
-  blur() {
-    this._selectEl?.blur();
-  }
-
-  /**
-   * Returns the options derived from child elements.
-   */
-  private get options(): SelectOption[] {
-    return Array.from(this.children).map((el) => ({
-      value: el.getAttribute('value') || '',
-      label: el.textContent || '',
-      disabled: el.hasAttribute('disabled'),
-    }));
+  #registerNativeMenuEvents() {
+    if (!this.#selectNativeMenu) {
+      this.#selectNativeMenu = new SelectNativeMenu();
+    }
+    this.#selectNativeMenu.registerEvents(
+      this,
+      () => {
+        const opts = this.options;
+        return opts;
+      },
+      () => this.getAttribute('value'),
+      (value: string) => this.setAttribute('value', value)
+    );
   }
 
-  private get wrapperClasses() {
+  get #useNativeMenu() {
+    return (
+      this.hasAttribute('usenativemenu') && window.electronAPI?.showNativeMenu
+    );
+  }
+
+  set options(val: any[]) {
+    (this as any)._options = val;
+    render(this.#template, this.shadowRoot!);
+  }
+  get options(): any[] {
+    return (this as any)._options;
+  }
+
+  get #wrapperClasses() {
     const size = this.getAttribute('size');
     const icon = this.getAttribute('icon');
     const iconPosition = this.getAttribute('icon-position');
@@ -90,7 +87,7 @@ export class SelectElement extends HTMLElement {
       .join(' ');
   }
 
-  private get selectClasses() {
+  get #selectClasses() {
     const size = this.getAttribute('size');
     const variant = this.getAttribute('variant');
     const loading = this.hasAttribute('loading');
@@ -104,32 +101,7 @@ export class SelectElement extends HTMLElement {
       .join(' ');
   }
 
-  private renderOptions() {
-    const nodes = [];
-    const placeholder = this.getAttribute('placeholder');
-    const value = this.getAttribute('value');
-    if (placeholder) {
-      nodes.push(
-        html`<option value="" disabled ?selected=${!value}>
-          ${placeholder}
-        </option>`
-      );
-    }
-    this.options.forEach((opt) => {
-      nodes.push(
-        html`<option
-          value=${opt.value}
-          ?disabled=${opt.disabled}
-          ?selected=${value === opt.value}
-        >
-          ${opt.label}
-        </option>`
-      );
-    });
-    return nodes;
-  }
-
-  private renderIcon(position: IconPosition) {
+  #valueIcon(position: IconPosition) {
     const icon = this.getAttribute('icon');
     const iconPosition = this.getAttribute('icon-position');
     const size = this.getAttribute('size') || 'medium';
@@ -141,7 +113,7 @@ export class SelectElement extends HTMLElement {
     ></un-icon>`;
   }
 
-  private renderDropdownIcon() {
+  #handleIcon() {
     const loading = this.hasAttribute('loading');
     const size = this.getAttribute('size') || 'medium';
     return loading
@@ -154,10 +126,7 @@ export class SelectElement extends HTMLElement {
       : html`<un-icon class="dropdown-icon" name="dropdown"></un-icon>`;
   }
 
-  /**
-   * Handles select value change.
-   */
-  private handleChange = (e: Event) => {
+  #handleChange = (e: Event) => {
     const select = e.target as HTMLSelectElement;
     this.setAttribute('value', select.value);
     this.dispatchEvent(
@@ -169,44 +138,70 @@ export class SelectElement extends HTMLElement {
     );
   };
 
-  /**
-   * Renders the component template.
-   */
-  render() {
+  get #template() {
+    return this.#useNativeMenu ? this.#nativeTemplate : this.#standardTemplate;
+  }
+
+  get #nativeTemplate() {
+    const value = this.getAttribute('value');
+    const disabled =
+      this.hasAttribute('disabled') || this.hasAttribute('loading');
+    const loading = this.hasAttribute('loading');
+    return html`
+      <div class="${this.#wrapperClasses}">
+        ${this.#valueIcon('start')}
+        <button
+          class=${this.#selectClasses}
+          part="select"
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded="false"
+          aria-disabled="${disabled}"
+          aria-busy="${loading ? 'true' : 'false'}"
+          ?disabled=${disabled}
+          tabindex="0"
+        >
+          ${SelectNativeMenu.findLabelForValue(this.options, value) ||
+          this.getAttribute('placeholder') ||
+          ''}
+        </button>
+        ${this.#valueIcon('end')} ${this.#handleIcon()}
+      </div>
+    `;
+  }
+
+  get #standardTemplate() {
     const value = this.getAttribute('value');
     const disabled =
       this.hasAttribute('disabled') || this.hasAttribute('loading');
     const required = this.hasAttribute('required');
     const name = this.getAttribute('name') ?? '';
     const loading = this.hasAttribute('loading');
-    render(
-      html`
-        <style>
-          ${SelectElement.styles}
-        </style>
-        <div class="${this.wrapperClasses}">
-          ${this.renderIcon('start')}
-          <select
-            class=${this.selectClasses}
-            .value=${value}
-            ?disabled=${disabled}
-            ?required=${required}
-            name=${name}
-            aria-busy=${loading ? 'true' : 'false'}
-          >
-            ${this.renderOptions()}
-          </select>
-          ${this.renderIcon('end')} ${this.renderDropdownIcon()}
-        </div>
-      `,
-      this.shadowRoot!
-    );
-    // Attach event listener after render
-    this._selectEl = this.shadowRoot!.querySelector('select')!;
-    if (this._selectEl) {
-      this._selectEl.removeEventListener('change', this.handleChange);
-      this._selectEl.addEventListener('change', this.handleChange);
-    }
+    return html`
+      <div class="${this.#wrapperClasses}">
+        ${this.#valueIcon('start')}
+        <select
+          class=${this.#selectClasses}
+          part="select"
+          .value=${value}
+          ?disabled=${disabled}
+          ?required=${required}
+          name=${name}
+          aria-busy=${loading ? 'true' : 'false'}
+          @change=${this.#handleChange}
+        >
+          <option value="" disabled ?selected=${!value}>
+            ${this.getAttribute('placeholder')}
+          </option>
+          ${Array.from(this.children)
+            .filter(
+              (node) => node.tagName === 'OPTION' || node.tagName === 'OPTGROUP'
+            )
+            .map((node) => html`${node.cloneNode(true)}`)}
+        </select>
+        ${this.#valueIcon('end')} ${this.#handleIcon()}
+      </div>
+    `;
   }
 
   static get styles() {
@@ -229,7 +224,7 @@ export class SelectElement extends HTMLElement {
         color: var(--input-text-color);
         font-family: inherit;
         font-size: inherit;
-        line-height: var(--select-height);
+        /* line-height: var(--select-height); */
         appearance: none;
         box-sizing: border-box;
         border: 1px solid var(--input-border-color);
@@ -239,22 +234,40 @@ export class SelectElement extends HTMLElement {
           transparent 50%
         );
         box-shadow: var(--button-shadows);
+
+        &:focus {
+          outline: var(--outline);
+          outline-offset: var(--outline-offset-inputs);
+        }
       }
-      .select:focus {
-        outline: var(--outline);
-        outline-offset: var(--outline-offset-inputs);
+
+      /* --- Shared variant styles --- */
+      .select--ghost,
+      .select--flat {
+        border-color: transparent;
+        box-shadow: none;
       }
+      .select--ghost {
+        background-color: transparent;
+        padding-right: var(--space-7);
+      }
+      .select--flat {
+        background-color: var(--input-bg-color-flat);
+      }
+
+      /* --- Disabled & loading states --- */
       .select:disabled,
-      .select.loading {
+      .select--loading {
         opacity: 0.5;
         cursor: not-allowed;
-      }
-      .loading {
         pointer-events: none;
       }
+
       .select option:disabled {
         color: var(--input-placeholder-color);
       }
+
+      /* --- Size variants --- */
       .select--small {
         --select-height: 18px;
         font-size: var(--text-sm);
@@ -262,28 +275,8 @@ export class SelectElement extends HTMLElement {
       .select--large {
         --select-height: 28px;
       }
-      .select--ghost {
-        border-color: transparent;
-        background-color: transparent;
-        box-shadow: none;
-        /* font-weight: 500; */
-        /* font-size: var(--text-sm); */
-        padding-right: var(--space-6);
-        /* margin-bottom: 2px; */
-      }
-      .select-wrapper:has(.select--ghost):hover un-icon.dropdown-icon {
-        opacity: 1;
-      }
-      .select--flat {
-        border-color: transparent;
-        box-shadow: none;
-        mix-blend-mode: multiply;
-        background-color: var(--input-bg-color-flat);
-      }
-      .select--flat + un-icon.dropdown-icon,
-      .select--flat ~ un-icon.dropdown-icon {
-        border-left-color: transparent;
-      }
+
+      /* --- Dropdown icon styles --- */
       un-icon.dropdown-icon {
         position: absolute;
         right: 1px;
@@ -299,20 +292,17 @@ export class SelectElement extends HTMLElement {
         align-items: center;
         justify-content: center;
       }
-      .select--ghost + un-icon.dropdown-icon,
-      .select--ghost ~ un-icon.dropdown-icon {
-        border: 1px solid var(--input-border-color);
-        border-top-color: color-mix(
-          in srgb,
-          var(--input-border-color) 100%,
-          transparent 50%
-        );
-        box-shadow: var(--button-shadows);
-        border-radius: var(--rounded);
-        height: 16px;
-        width: 16px;
+      .select--flat + .dropdown-icon {
+        border-left-color: transparent;
+      }
+      .select--ghost + .dropdown-icon {
+        border: unset;
+        border-left-color: transparent;
+        border-top-color: transparent;
+        box-shadow: none;
         right: var(--space-2);
       }
+
       un-icon.value-icon {
         position: absolute;
         top: 50%;
@@ -320,12 +310,13 @@ export class SelectElement extends HTMLElement {
         pointer-events: none;
         color: var(--input-text-color);
         z-index: 1;
-      }
-      un-icon.value-icon-start {
-        left: var(--space-4);
-      }
-      un-icon.value-icon-end {
-        right: calc(20px + var(--space-4));
+
+        &.value-icon-start {
+          left: var(--space-4);
+        }
+        &.value-icon-end {
+          right: calc(20px + var(--space-4));
+        }
       }
       .has-icon.icon-start select {
         padding-left: calc(var(--space-4) + 16px);

--- a/desktop/src/ui/common/styles/theme.css
+++ b/desktop/src/ui/common/styles/theme.css
@@ -4,7 +4,7 @@
   *******************************************************/
 
   --color-grey-0: oklch(99.1% 0.002 271.4);
-  --color-gray-25: oklch(97.8% 0.005 260.7);
+  --color-grey-25: oklch(97.8% 0.005 260.7);
   --color-grey-50: oklch(95.2% 0.005 271.3);
   --color-grey-100: oklch(92.7% 0.005 258.3);
   --color-grey-150: oklch(89.7% 0.008 267.4);
@@ -15,7 +15,7 @@
   --color-grey-600: oklch(54.9% 0.008 261.8);
   --color-grey-700: oklch(48.4% 0.008 267.3);
   --color-grey-800: oklch(41.2% 0.008 261.8);
-  --color-grey-850: oklch(42.2% 0.008 261.8);
+  --color-grey-850: oklch(37.4% 0.013 261.7);
   --color-grey-900: oklch(34.3% 0.008 258.4);
   --color-grey-950: oklch(31.3% 0.008 264.3);
   --color-grey-975: oklch(28% 0.01 261.7);

--- a/desktop/src/ui/top-bar/top-bar.ts
+++ b/desktop/src/ui/top-bar/top-bar.ts
@@ -83,6 +83,11 @@ export class TopBar extends HTMLElement {
     const activeWorkspaceId =
       this.workspaceModel.activeWorkspaceId || (workspaces[0]?.id ?? '');
 
+    const workspaceOptions = [
+      ...workspaces.map((ws) => ({ value: ws.id, label: ws.title })),
+      { value: '+', label: 'New workspace...' },
+    ];
+
     const selectTemplate = html`
       <un-button
         type="ghost"
@@ -92,8 +97,10 @@ export class TopBar extends HTMLElement {
       >
       </un-button>
       <un-select
+        usenativemenu
         variant="ghost"
         .value=${activeWorkspaceId}
+        .options=${workspaceOptions}
         placeholder="Select workspace"
         @change=${(e: CustomEvent) => {
           const newId = e.detail.value;
@@ -104,12 +111,6 @@ export class TopBar extends HTMLElement {
           }
         }}
       >
-        ${repeat(
-          workspaces,
-          (ws) => ws.id,
-          (ws) => html`<option value=${ws.id}>${ws.title}</option>`
-        )}
-        <option value="+">New workspace...</option>
       </un-select>
     `;
 

--- a/desktop/src/ui/top-bar/top-bar.ts
+++ b/desktop/src/ui/top-bar/top-bar.ts
@@ -89,13 +89,6 @@ export class TopBar extends HTMLElement {
     ];
 
     const selectTemplate = html`
-      <un-button
-        type="ghost"
-        icon="info"
-        class="settings-button"
-        @click=${() => this.modalService.open('workspace-settings')}
-      >
-      </un-button>
       <un-select
         usenativemenu
         variant="ghost"
@@ -112,6 +105,13 @@ export class TopBar extends HTMLElement {
         }}
       >
       </un-select>
+      <un-button
+        type="ghost"
+        icon="pencil"
+        class="settings-button"
+        @click=${() => this.modalService.open('workspace-settings')}
+      >
+      </un-button>
     `;
 
     render(selectTemplate, this.workspaceSelectContainer!);

--- a/desktop/src/ui/top-bar/top-bar.ts
+++ b/desktop/src/ui/top-bar/top-bar.ts
@@ -9,30 +9,6 @@ import './tab-handle';
 import './top-bar.css';
 import { ModalService } from '../../modals/modal-service';
 
-// Define electronAPI type for TypeScript
-declare global {
-  interface Window {
-    electronAPI?: {
-      onWindowStateChange: (callback: (isFullscreen: boolean) => void) => void;
-      removeWindowStateListeners: () => void;
-      platform: string;
-      isFullScreen: () => Promise<boolean>;
-    };
-  }
-}
-
-// Define electronAPI type for TypeScript
-declare global {
-  interface Window {
-    electronAPI?: {
-      onWindowStateChange: (callback: (isFullscreen: boolean) => void) => void;
-      removeWindowStateListeners: () => void;
-      platform: string;
-      isFullScreen: () => Promise<boolean>;
-    };
-  }
-}
-
 export class TopBar extends HTMLElement {
   modalService = dependencies.resolve<ModalService>('ModalService');
   workspaceModel = dependencies.resolve<WorkspaceModel>('WorkspaceModel');

--- a/desktop/src/ui/workspaces/process-view.ts
+++ b/desktop/src/ui/workspaces/process-view.ts
@@ -1,5 +1,5 @@
 import { ProcessContainer } from '@unternet/kernel';
-import './process-view.css';
+// import './process-view.css';
 
 class ProcessView extends HTMLElement {
   #process: ProcessContainer | null = null;

--- a/desktop/theme-demo.js
+++ b/desktop/theme-demo.js
@@ -1,16 +1,24 @@
 // theme-demo.js
-import { ICON } from './src/ui/common/elements/icon.ts';
+import { icons } from './src/ui/common/elements/icon-registry.ts';
+
+function pascalToKebab(str) {
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
 
 function generateIconGrid() {
   const iconGrid = document.getElementById('icon-grid');
-  let iconsHtml = Object.entries(ICON)
-    .map(
-      ([key, value]) => `
-        <div class="icon-item" title="${key}${key !== value ? ` (${value})` : ''}">
-          <un-icon name="${key}"></un-icon>
+  let iconsHtml = Object.entries(icons)
+    .map(([key]) => {
+      const kebabName = pascalToKebab(key);
+      return `
+        <div class="icon-item" title="${key}">
+          <un-icon name="${kebabName}"></un-icon>
         </div>
-      `
-    )
+      `;
+    })
     .join('');
   iconGrid.innerHTML = iconsHtml;
 }

--- a/desktop/theme.html
+++ b/desktop/theme.html
@@ -513,6 +513,133 @@ return "Hello, World!";
           </div>
 
           <div class="form-group">
+            <h4>Select (Native Menu, Simple)</h4>
+            <!-- When using usenativemenu, you must provide options via the 'options' attribute. <option> children are ignored. -->
+            <script>
+              window.demoOptionsSimple = [
+                { label: '-- Please select --', value: '' },
+                { label: 'Short', value: 'short' },
+                {
+                  label:
+                    'This is a very, very, very, very, very, very, very, very, very, very, very, very, very, very long option label to test overflow handling',
+                  value: 'long',
+                },
+                { label: '😀 Emoji Option', value: 'emoji' },
+                {
+                  label: 'Special & Characters: <Test> & "Quotes"',
+                  value: 'specialchars',
+                },
+                { label: 'Disabled Option', value: 'disabled', disabled: true },
+                { label: ' ', value: 'empty' },
+                { label: 'Unicode: 你好, мир, مرحبا', value: 'unicode' },
+                { type: 'separator' },
+                { label: 'After separator', value: 'aftersep' },
+              ];
+            </script>
+            <un-select
+              id="demo-select-simple"
+              usenativemenu
+              placeholder="Choose..."
+            ></un-select>
+          </div>
+
+          <div class="form-group">
+            <h4>Select (Native Menu, options attribute)</h4>
+            <script>
+              window.demoOptionsComplex = [
+                { label: 'Simple Option', value: 'simple' },
+                { type: 'separator' },
+                {
+                  label: 'Checkbox Option',
+                  type: 'checkbox',
+                  checked: true,
+                  value: 'cb1',
+                },
+                {
+                  label: 'Checkbox Option 2',
+                  type: 'checkbox',
+                  checked: false,
+                  value: 'cb2',
+                  disabled: true,
+                },
+                { type: 'separator' },
+                {
+                  label: 'Radio Group',
+                  type: 'submenu',
+                  submenu: [
+                    {
+                      label: 'Radio 1',
+                      type: 'radio',
+                      checked: true,
+                      value: 'r1',
+                      group: 'group1',
+                    },
+                    {
+                      label: 'Radio 2',
+                      type: 'radio',
+                      checked: false,
+                      value: 'r2',
+                      group: 'group1',
+                    },
+                    {
+                      label: 'Radio 3',
+                      type: 'radio',
+                      checked: false,
+                      value: 'r3',
+                      group: 'group1',
+                    },
+                  ],
+                },
+                {
+                  label: 'Submenu Test',
+                  type: 'submenu',
+                  submenu: [
+                    { label: 'Sub Option 1', value: 'sub1' },
+                    { label: 'Sub Option 2', value: 'sub2', disabled: true },
+                    { type: 'separator' },
+                    { label: 'Sub Option 3', value: 'sub3' },
+                  ],
+                },
+                { type: 'separator' },
+                {
+                  label: 'Option with Icon',
+                  value: 'iconopt',
+                  icon: 'build/app-icons/client-icon-linux-32.png',
+                },
+                {
+                  label: 'Shortcuts',
+                  value: 'accel',
+                  accelerator: 'CommandOrControl+Y',
+                },
+                { label: 'Unicode Option 🌍', value: 'unicode' },
+                { label: 'Special & <Characters>', value: 'specialchars' },
+                {
+                  label: 'Sublabel/Tooltip',
+                  value: 'sublabel',
+                  toolTip: 'unfortunately, sublabel does not work on macOS',
+                  sublabel: 'Sublabel',
+                },
+                { label: 'Disabled Option', value: 'disabled', disabled: true },
+              ];
+            </script>
+            <un-select
+              id="demo-select-complex"
+              usenativemenu
+              placeholder="Choose..."
+            ></un-select>
+            <script>
+              document.addEventListener('DOMContentLoaded', () => {
+                const elSimple = document.getElementById('demo-select-simple');
+                const elComplex = document.getElementById(
+                  'demo-select-complex'
+                );
+                elSimple.options = window.demoOptionsSimple;
+                elComplex.options = window.demoOptionsComplex;
+              });
+            </script>
+          </div>
+
+          <div class="form-group">
             <h4>Textarea</h4>
             <un-textarea
               placeholder="Enter multiple lines of text"


### PR DESCRIPTION
This addresses #194 but also:
1. Cleans up <un-icon /> to have our icon list managed through a new `icon-registry.ts` file
2. Fixes the bug where the workspace selector wasn't updating when you created a new workspace
3. Adds a powerful new `usenativemenu` option to the <un-select /> component