### PR TITLE
fix: some issues with local applets

### DIFF
--- a/desktop/src/models/resource-model.ts
+++ b/desktop/src/models/resource-model.ts
@@ -44,11 +44,9 @@ class ResourceModel {
 
   async load() {
     const allResources = await this.db.all();
+
     for (const resource of allResources) {
-      // Ignore (removed) local applets, add all the rest.
-      if (!resource.uri.startsWith('applet+local:')) {
-        this.resources.set(resource.uri, resource);
-      }
+      this.resources.set(resource.uri, resource);
     }
     this.notifier.notify();
   }
@@ -77,13 +75,12 @@ class ResourceModel {
 
   add(resource: Resource) {
     this.resources.set(resource.uri, resource);
-    this.db.put(resource);
+    if (!resource.uri.startsWith('applet+local:')) this.db.put(resource);
     this.notifier.notify();
   }
 
   get(uri: string) {
     const result = this.resources.get(uri);
-    console.log(this.resources);
     if (!result) {
       throw new Error(`No resource matches this URI: ${JSON.stringify(uri)}`);
     }


### PR DESCRIPTION
Fixes:
- Some applet scanning problems. Most importantly, it required a `manifest.json` file to be present in the same directory as the `index.html` file. This isn't always the case, so I removed that requirement and instead look in the HTML file if there's a `<link rel="manifest">` tag present.
- Now uses the dir name of the first level as the hostname instead of `localhost`. Which technically should allow for origin separation (hopefully).
- It was adding local applets to the resource database, which should not happen.